### PR TITLE
Issue/5 ssh sidecar fixes

### DIFF
--- a/sshd-entrypoint.sh
+++ b/sshd-entrypoint.sh
@@ -31,20 +31,20 @@ grep -e "$LOAD_ENV_CMD" "$INMANTA_PROFILE" || echo "$LOAD_ENV_CMD" >> "$INMANTA_
 
 # Configure ssh server
 apt-get install -y openssh-server
-if [ ! -f /etc/ssh/ssh_host_* ]; then
-    ssh-keygen -A
-fi
+[ -f /etc/ssh/ssh_host_* ] || ssh-keygen -A
 
 # Configure the inmanta user remote access
 mkdir -p "$INMANTA_USER_HOME_DIR/.ssh"
 chmod 700 "$INMANTA_USER_HOME_DIR" "$INMANTA_USER_HOME_DIR/.ssh"
-echo "$INMANTA_USER_AUTHORIZED_KEYS" >> "$INMANTA_USER_HOME_DIR/.ssh/authorized_keys"
+if [ "$INMANTA_USER_AUTHORIZED_KEYS" != "" ]; then
+    echo "$INMANTA_USER_AUTHORIZED_KEYS" > "$INMANTA_USER_HOME_DIR/.ssh/authorized_keys"
+fi
 chown -R inmanta:inmanta "$INMANTA_USER_HOME_DIR"
 chmod 600 "$INMANTA_USER_HOME_DIR/.ssh/authorized_keys"
 
 # Create an ssh key for local usage (healthcheck)
-ssh-keygen -t rsa -b 4096 -f /root/.ssh/id_rsa
-cat /root/.ssh/id_rsa.pub >> "$INMANTA_USER_HOME_DIR/.ssh/authorized_keys"
+[ -f /root/.ssh/id_rsa ] || ssh-keygen -t rsa -b 4096 -f /root/.ssh/id_rsa
+grep "$(cat /root/.ssh/id_rsa.pub)" "$INMANTA_USER_HOME_DIR/.ssh/authorized_keys" || cat /root/.ssh/id_rsa.pub >> "$INMANTA_USER_HOME_DIR/.ssh/authorized_keys"
 
 # Start the ssh server, make it become the main process
 mkdir -p /run/sshd

--- a/sshd-entrypoint.sh
+++ b/sshd-entrypoint.sh
@@ -31,11 +31,12 @@ grep -e "$LOAD_ENV_CMD" "$INMANTA_PROFILE" || echo "$LOAD_ENV_CMD" >> "$INMANTA_
 
 # Configure ssh server
 apt-get install -y openssh-server
-[ -f /etc/ssh/ssh_host_* ] || ssh-keygen -A
+ssh-keygen -A
 
 # Configure the inmanta user remote access
 mkdir -p "$INMANTA_USER_HOME_DIR/.ssh"
 chmod 700 "$INMANTA_USER_HOME_DIR" "$INMANTA_USER_HOME_DIR/.ssh"
+touch "$INMANTA_USER_HOME_DIR/.ssh/authorized_keys"
 if [ "$INMANTA_USER_AUTHORIZED_KEYS" != "" ]; then
     echo "$INMANTA_USER_AUTHORIZED_KEYS" > "$INMANTA_USER_HOME_DIR/.ssh/authorized_keys"
 fi


### PR DESCRIPTION
- Fix restart of ssh sidecar (would get stuck on root ssh key overwrite)
- Stabilize authorized_keys file content (don't add root pub key on each restart)
- Drop useless and broken file check for generating the host keys

Closes #5 